### PR TITLE
liblineage: wiki: data_types: screen_data: Deprecate density prop

### DIFF
--- a/liblineage/wiki/data_types/screen_data.py
+++ b/liblineage/wiki/data_types/screen_data.py
@@ -13,7 +13,6 @@ class ScreenData(BaseData):
 
 	Attributes:
 	- size: The screen size (inches)
-	- density: The screen density (dpi)
 	- resolution: The screen resolution (e.g. 1080x1920)
 	- technology: The screen technology (e.g. LCD)
 	- refresh_rate: Maximum screen refresh rate (Hz)
@@ -21,7 +20,6 @@ class ScreenData(BaseData):
 	def __init__(
 		self,
 		size: str,
-		density: int,
 		resolution: str,
 		technology: str,
 		refresh_rate: Optional[int] = None,
@@ -30,7 +28,6 @@ class ScreenData(BaseData):
 		super().__init__()
 
 		self.size = size
-		self.density = density
 		self.resolution = resolution
 		self.technology = technology
 		self.refresh_rate = refresh_rate


### PR DESCRIPTION
* Has been removed since https://github.com/LineageOS/lineage_wiki/commit/08e8ce596b1796da58f8ed8f5989bbfee3cd224e

Change-Id: Id47dd1954903721b3b0074cfbc6ef4b4af984755